### PR TITLE
added new filters when creating a run

### DIFF
--- a/app/dataController/runs.controller.ts
+++ b/app/dataController/runs.controller.ts
@@ -22,6 +22,7 @@ export interface ICreateRuns {
   createdBy: number
   filterType?: 'and' | 'or'
   platformIds?: number[]
+  priorityIds?: number[]
 }
 
 export interface IUpdateRun {

--- a/app/dataController/runs.controller.ts
+++ b/app/dataController/runs.controller.ts
@@ -16,13 +16,13 @@ export interface ICreateRuns {
   projectId: number
   runName: string
   runDescription?: string | null
-  labelIds?: number[]
-  squadIds?: number[]
-  sectionIds?: number[]
+  labelIds?: number[] | null
+  squadIds?: number[] | null
+  sectionIds?: number[] | null
   createdBy: number
   filterType?: 'and' | 'or'
-  platformIds?: number[]
-  priorityIds?: number[]
+  platformIds?: number[] | null
+  priorityIds?: number[] | null
 }
 
 export interface IUpdateRun {

--- a/app/dataController/tests.controller.ts
+++ b/app/dataController/tests.controller.ts
@@ -45,6 +45,7 @@ export interface ITestsCountController {
   textSearch?: string
   sectionIds?: number[]
   platformIds?: number[]
+  priorityIds?: number[]
 }
 
 export interface IUpdateTests {

--- a/app/db/dao/runs.dao.ts
+++ b/app/db/dao/runs.dao.ts
@@ -93,6 +93,7 @@ const RunsDao = {
     filterType,
     sectionIds,
     platformIds,
+    priorityIds,
   }: ICreateRuns) => {
     try {
       const resp = await dbClient.transaction(async (trx) => {
@@ -116,6 +117,9 @@ const RunsDao = {
 
         if (platformIds?.length)
           whereClauses.push(inArray(tests.platformId, platformIds))
+
+        if (priorityIds?.length)
+          whereClauses.push(inArray(tests.priorityId, priorityIds))
 
         if (sectionIds?.length)
           andWhereCluase.push(inArray(tests.sectionId, sectionIds))

--- a/app/db/dao/test.dao.ts
+++ b/app/db/dao/test.dao.ts
@@ -168,6 +168,7 @@ const TestsDao = {
     textSearch,
     sectionIds,
     platformIds,
+    priorityIds,
   }: ITestsCountController) {
     try {
       const andWhereCluase: any[] = [
@@ -194,6 +195,14 @@ const TestsDao = {
           whereClauses.push(inArray(tests.platformId, platformIds))
         else
           throw new Error('Empty platformIds provided', {
+            cause: ErrorCause.INVALID_PARAMS,
+          })
+
+      if (priorityIds)
+        if (priorityIds.length > 0)
+          whereClauses.push(inArray(tests.priorityId, priorityIds))
+        else
+          throw new Error('Empty priorityIds provided', {
             cause: ErrorCause.INVALID_PARAMS,
           })
 

--- a/app/routes/api/v1/createRun.ts
+++ b/app/routes/api/v1/createRun.ts
@@ -16,11 +16,12 @@ const CreateRunRequestSchema = z.object({
     .min(5, {message: 'Run name must be at least 5 characters'})
     .max(50, {message: 'Run name must be at most 50 characters'}),
   runDescription: z.string().optional().nullable(),
-  labelIds: z.array(z.number()).optional(),
-  squadIds: z.array(z.number()).optional(),
-  sectionIds: z.array(z.number()).optional(),
+  labelIds: z.array(z.number()).optional().nullable(),
+  squadIds: z.array(z.number()).optional().nullable(),
+  sectionIds: z.array(z.number()).optional().nullable(),
   filterType: z.enum(['and', 'or']).optional().nullable(),
-  platformIds: z.array(z.number()).optional(),
+  platformIds: z.array(z.number()).optional().nullable(),
+  priorityIds: z.array(z.number()).optional().nullable(),
 })
 
 export type CreateRunRequestAPIType = z.infer<typeof CreateRunRequestSchema>

--- a/app/routes/utilities/getSearchParams.ts
+++ b/app/routes/utilities/getSearchParams.ts
@@ -92,6 +92,9 @@ const SearchParams = {
     const platformIds = searchParams.platformIds
       ? jsonParseWithError(searchParams.platformIds, 'platformIds')
       : undefined
+    const priorityIds = searchParams.priorityIds
+      ? jsonParseWithError(searchParams.priorityIds, 'priorityIds')
+      : undefined
     const filterType = searchParams.filterType
       ? (searchParams.filterType as ITestsController['filterType'])
       : 'and'
@@ -106,6 +109,7 @@ const SearchParams = {
       platformIds,
       squadIds,
       labelIds,
+      priorityIds,
       filterType,
       includeTestIds,
     }

--- a/app/screens/TestList/AddRunDialog.tsx
+++ b/app/screens/TestList/AddRunDialog.tsx
@@ -1,0 +1,460 @@
+import {StateDialog} from '@components/Dialog/StateDialog'
+import {FilterDropdown} from '@components/MultipleUnifiedFilter/FilterDropdown'
+import {InputsSpacing} from '@components/Forms/InputsSpacing'
+import {DialogDescription, DialogTitle} from '@radix-ui/react-dialog'
+import {useFetcher, useParams} from '@remix-run/react'
+import {Button} from '@ui/button'
+import {DialogClose} from '@ui/dialog'
+import {Input} from '@ui/input'
+import {Label} from '@ui/label'
+import {RadioGroup, RadioGroupItem} from '@ui/radio-group'
+import {Skeleton} from '@ui/skeleton'
+import {RotateCcw} from 'lucide-react'
+import {useEffect, useState} from 'react'
+import {
+  AND_SELECTION,
+  MULTIPLE_SELECTED,
+  NONE_SELECTED,
+  OR_SELECTION,
+} from '~/constants'
+import {API} from '~/routes/utilities/api'
+import {ORG_ID} from '~/routes/utilities/constants'
+import {FilterNames} from './testTable.interface'
+import {InputLabels} from './InputLabels'
+import {Squad} from '~/screens/RunTestList/interfaces'
+import {TestListFilter} from '@components/MultipleUnifiedFilter/MultipleUnifiedFilter'
+
+interface Labels {
+  labelName: string
+  labelId: number
+  labelType: string
+}
+
+interface Platforms {
+  platformName: string
+  platformId: number
+}
+
+interface Priority {
+  priorityName: string
+  priorityId: number
+}
+
+interface AddRunDialogProps {
+  handleSaveChanges: (data: {
+    runName: string
+    runDescription: string
+    squadIds: number[]
+    labelIds: number[]
+    platformIds: number[]
+    priorityIds: number[]
+    filterType: 'and' | 'or'
+  }) => void
+  state: boolean
+  setState: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+export const AddRunDialog = ({
+  handleSaveChanges,
+  state,
+  setState,
+}: AddRunDialogProps) => {
+  const pathParams = useParams()
+  const projectId = Number(pathParams?.projectId)
+  const orgId = ORG_ID
+
+  const [runName, setRunName] = useState<string>('')
+  const [runDescription, setRunDescription] = useState<string>('')
+  const [filterType, setFilterType] = useState<'and' | 'or'>('and')
+  const [filters, setFilters] = useState<TestListFilter[]>([])
+
+  const squadsFetcher = useFetcher<{data: Squad[]}>()
+  const labelsFetcher = useFetcher<{data: Labels[]}>()
+  const platformFetcher = useFetcher<{data: Platforms[]}>()
+  const priorityFetcher = useFetcher<{data: Priority[]}>()
+  const testCountFetcher = useFetcher<{data: {count: number}}>()
+
+  // Fetch filter options when dialog opens
+  useEffect(() => {
+    if (state) {
+      platformFetcher.load(`/${API.GetPlatforms}?orgId=${orgId}`)
+      priorityFetcher.load(`/${API.GetPriority}?orgId=${orgId}`)
+      squadsFetcher.load(`/${API.GetSquads}?projectId=${projectId}`)
+      labelsFetcher.load(`/${API.GetLabels}?projectId=${projectId}`)
+    }
+  }, [state, projectId, orgId])
+
+  // Build filters from fetched data
+  useEffect(() => {
+    const squads = squadsFetcher.data?.data
+    if (squads) {
+      setFilters((prev) => {
+        const isSquadFilterPresent = prev.some(
+          (f) => f.filterName === FilterNames.Squad,
+        )
+        if (isSquadFilterPresent) return prev
+        return [
+          ...prev,
+          {
+            filterName: FilterNames.Squad,
+            filterOptions: [
+              ...squads.map((squad) => ({
+                id: squad.squadId,
+                optionName: squad.squadName,
+                checked: false,
+              })),
+              {
+                id: 0,
+                optionName: 'No Squad',
+                checked: false,
+              },
+            ],
+          },
+        ]
+      })
+    }
+  }, [squadsFetcher.data])
+
+  useEffect(() => {
+    const labels = labelsFetcher.data?.data
+    if (labels) {
+      setFilters((prev) => {
+        const isLabelFilterPresent = prev.some(
+          (f) => f.filterName === FilterNames.Label,
+        )
+        if (isLabelFilterPresent) return prev
+        return [
+          ...prev,
+          {
+            filterName: FilterNames.Label,
+            filterOptions: labels.map((label) => ({
+              id: label.labelId,
+              optionName: label.labelName,
+              checked: false,
+            })),
+          },
+        ]
+      })
+    }
+  }, [labelsFetcher.data])
+
+  useEffect(() => {
+    const platforms = platformFetcher.data?.data
+    if (platforms) {
+      setFilters((prev) => {
+        const isPlatformFilterPresent = prev.some(
+          (f) => f.filterName === FilterNames.Platform,
+        )
+        if (isPlatformFilterPresent) return prev
+        return [
+          ...prev,
+          {
+            filterName: FilterNames.Platform,
+            filterOptions: platforms.map((platform) => ({
+              id: platform.platformId,
+              optionName: platform.platformName,
+              checked: false,
+            })),
+          },
+        ]
+      })
+    }
+  }, [platformFetcher.data])
+
+  useEffect(() => {
+    const priorities = priorityFetcher.data?.data
+    if (priorities) {
+      setFilters((prev) => {
+        const isPriorityFilterPresent = prev.some(
+          (f) => f.filterName === FilterNames.Priority,
+        )
+        if (isPriorityFilterPresent) return prev
+        return [
+          ...prev,
+          {
+            filterName: FilterNames.Priority,
+            filterOptions: priorities.map((priority) => ({
+              id: priority.priorityId,
+              optionName: priority.priorityName,
+              checked: false,
+            })),
+          },
+        ]
+      })
+    }
+  }, [priorityFetcher.data])
+
+  // Fetch test count based on selected filters
+  useEffect(() => {
+    if (!state) return
+
+    const squadIds = getSelectedIds(FilterNames.Squad)
+    const labelIds = getSelectedIds(FilterNames.Label)
+    const platformIds = getSelectedIds(FilterNames.Platform)
+    const priorityIds = getSelectedIds(FilterNames.Priority)
+
+    let url = `/${API.GetTestsCount}?projectId=${projectId}`
+
+    if (squadIds.length > 0 || labelIds.length > 0 || platformIds.length > 0 || priorityIds.length > 0) {
+      url += `&filterType=${filterType}`
+      if (squadIds.length > 0) url += `&squadIds=${JSON.stringify(squadIds)}`
+      if (labelIds.length > 0) url += `&labelIds=${JSON.stringify(labelIds)}`
+      if (platformIds.length > 0)
+        url += `&platformIds=${JSON.stringify(platformIds)}`
+      if (priorityIds.length > 0)
+        url += `&priorityIds=${JSON.stringify(priorityIds)}`
+    }
+
+    testCountFetcher.load(url)
+  }, [filters, filterType, state, projectId])
+
+  const getSelectedIds = (filterName: FilterNames): number[] => {
+    const filter = filters.find((f) => f.filterName === filterName)
+    if (!filter) return []
+    return filter.filterOptions
+      .filter((option) => option.checked)
+      .map((option) => option.id ?? 0)
+  }
+
+  const handleCheckboxChange = ({
+    filterName,
+    optionName,
+  }: {
+    filterName: FilterNames
+    optionName: string
+    optionId?: number
+  }) => {
+    setFilters((prev) =>
+      prev.map((filter) => {
+        if (filter.filterName === filterName) {
+          return {
+            ...filter,
+            filterOptions: filter.filterOptions.map((option) => {
+              if (option.optionName === optionName) {
+                return {...option, checked: !option.checked}
+              }
+              return option
+            }),
+          }
+        }
+        return filter
+      }),
+    )
+  }
+
+  const resetFilter = (filterName: FilterNames) => {
+    setFilters((prev) =>
+      prev.map((filter) => {
+        if (filter.filterName === filterName) {
+          return {
+            ...filter,
+            filterOptions: filter.filterOptions.map((option) => ({
+              ...option,
+              checked: false,
+            })),
+          }
+        }
+        return filter
+      }),
+    )
+  }
+
+  const resetAllFilters = () => {
+    setFilters((prev) =>
+      prev.map((filter) => ({
+        ...filter,
+        filterOptions: filter.filterOptions.map((option) => ({
+          ...option,
+          checked: false,
+        })),
+      })),
+    )
+  }
+
+  const handleSubmit = () => {
+    handleSaveChanges({
+      runName,
+      runDescription,
+      squadIds: getSelectedIds(FilterNames.Squad),
+      labelIds: getSelectedIds(FilterNames.Label),
+      platformIds: getSelectedIds(FilterNames.Platform),
+      priorityIds: getSelectedIds(FilterNames.Priority),
+      filterType,
+    })
+    // Reset state after submission
+    setRunName('')
+    setRunDescription('')
+    setFilterType('and')
+    resetAllFilters()
+  }
+
+  const testCount = testCountFetcher.data?.data?.count
+  const isLoading =
+    squadsFetcher.state === 'loading' ||
+    labelsFetcher.state === 'loading' ||
+    platformFetcher.state === 'loading' ||
+    priorityFetcher.state === 'loading'
+
+  const hasAnyFilterSelected = filters.some((f) =>
+    f.filterOptions.some((o) => o.checked),
+  )
+
+  return (
+    <StateDialog
+      variant={'add'}
+      setState={setState}
+      state={state}
+      headerComponent={
+        <>
+          <DialogTitle className="font-semibold text-lg">Add Run</DialogTitle>
+          <DialogDescription className="text-xs text-slate-500">
+            Create a new test run with optional filters
+          </DialogDescription>
+        </>
+      }
+      contentComponent={
+        <div className="pb-4 max-h-[70vh] overflow-y-auto">
+          {/* Run Name */}
+          <InputLabels
+            className="text-xs font-normal"
+            labelName="Run Name"
+            isMandatory={true}
+          />
+          <Input
+            id="runName"
+            onChange={(e) => setRunName(e.target.value)}
+            className="col-span-3"
+            value={runName}
+            placeholder="Enter run name"
+          />
+
+          <InputsSpacing />
+
+          {/* Run Description */}
+          <InputLabels className="text-xs font-normal" labelName="Run Description" />
+          <Input
+            id="runDescription"
+            onChange={(e) => setRunDescription(e.target.value)}
+            className="col-span-3"
+            value={runDescription}
+            placeholder="Enter run description (optional)"
+          />
+
+          <InputsSpacing />
+
+          {/* Filter Section */}
+          <div className="border-t border-slate-200 pt-4 mt-2">
+            <div className="flex items-center justify-between mb-3">
+              <InputLabels
+                className="text-xs font-medium"
+                labelName="Filter Tests (Optional)"
+              />
+              {hasAnyFilterSelected && (
+                <button
+                  onClick={resetAllFilters}
+                  className="text-xs text-slate-500 hover:text-slate-700 flex items-center gap-1">
+                  <RotateCcw size={12} />
+                  Reset all
+                </button>
+              )}
+            </div>
+
+            {isLoading ? (
+              <div className="grid grid-cols-2 gap-3">
+                <Skeleton className="h-9 w-full" />
+                <Skeleton className="h-9 w-full" />
+                <Skeleton className="h-9 w-full" />
+                <Skeleton className="h-9 w-full" />
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 gap-3">
+                {filters.map((filter, index) => (
+                  <div key={index} className="flex items-center gap-1">
+                    <FilterDropdown
+                      key={filter.filterName}
+                      filter={filter}
+                      handleCheckboxChange={handleCheckboxChange}
+                    />
+                    {filter.filterOptions.some((option) => option.checked) && (
+                      <button
+                        onClick={() => resetFilter(filter.filterName)}
+                        className="p-1.5 hover:bg-slate-100 rounded-md transition-colors">
+                        <RotateCcw
+                          className="text-slate-500 hover:text-slate-700"
+                          size={14}
+                          strokeWidth={2}
+                        />
+                      </button>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Match Criteria */}
+            {hasAnyFilterSelected && (
+              <div className="mt-4 pt-4 border-t border-slate-200">
+                <h4 className="text-xs font-semibold text-slate-700 mb-2 uppercase tracking-wide">
+                  Match Criteria
+                </h4>
+                <RadioGroup
+                  value={filterType}
+                  onValueChange={(value: 'and' | 'or') => setFilterType(value)}>
+                  <div className="flex items-center space-x-2 py-1">
+                    <RadioGroupItem value="and" id="and" />
+                    <Label
+                      className="text-sm text-slate-600 font-normal cursor-pointer"
+                      htmlFor="and">
+                      {AND_SELECTION}
+                    </Label>
+                  </div>
+                  <div className="flex items-center space-x-2 py-1">
+                    <RadioGroupItem value="or" id="or" />
+                    <Label
+                      className="text-sm text-slate-600 font-normal cursor-pointer"
+                      htmlFor="or">
+                      {OR_SELECTION}
+                    </Label>
+                  </div>
+                </RadioGroup>
+              </div>
+            )}
+          </div>
+
+          {/* Test Count */}
+          <div className="mt-4 pt-4 border-t border-slate-200">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium text-slate-700">
+                Tests to include:
+              </span>
+              {testCountFetcher.state === 'loading' ? (
+                <Skeleton className="h-6 w-16" />
+              ) : (
+                <span className="text-sm font-semibold text-slate-900 bg-slate-100 px-2 py-1 rounded">
+                  {testCount ?? 0} tests
+                </span>
+              )}
+            </div>
+            {!hasAnyFilterSelected && (
+              <p className="text-xs text-slate-500 mt-1">{NONE_SELECTED}</p>
+            )}
+            {hasAnyFilterSelected && (
+              <p className="text-xs text-slate-500 mt-1">{MULTIPLE_SELECTED}</p>
+            )}
+          </div>
+        </div>
+      }
+      footerComponent={
+        <DialogClose asChild>
+          <Button
+            type="submit"
+            disabled={!runName.trim() || testCount === 0}
+            onClick={handleSubmit}>
+            Add Run
+          </Button>
+        </DialogClose>
+      }
+    />
+  )
+}
+

--- a/app/screens/TestList/AddSquadsLabelsDialog.tsx
+++ b/app/screens/TestList/AddSquadsLabelsDialog.tsx
@@ -1,15 +1,13 @@
 import {StateDialog} from '@components/Dialog/StateDialog'
-import {InputsSpacing} from '@components/Forms/InputsSpacing'
 import {DialogDescription, DialogTitle} from '@radix-ui/react-dialog'
 import {Button} from '@ui/button'
 import {DialogClose} from '@ui/dialog'
 import {Input} from '@ui/input'
 import {useState} from 'react'
-import {InputLabels} from './InputLabels'
 
 interface AddSquadsLabelsDialogProps {
   heading: string
-  handleSaveChanges: (value: string, description?: string) => void
+  handleSaveChanges: (value: string) => void
   state: boolean
   setState: React.Dispatch<React.SetStateAction<boolean>>
 }
@@ -21,7 +19,6 @@ export const AddSquadsLabelsDialog = ({
   setState,
 }: AddSquadsLabelsDialogProps) => {
   const [value, setValue] = useState<string>('')
-  const [description, setDescription] = useState<string>('')
 
   return (
     <StateDialog
@@ -32,67 +29,28 @@ export const AddSquadsLabelsDialog = ({
         <>
           <DialogTitle className="font-semibold text-lg">{`Add ${heading}`}</DialogTitle>
           <DialogDescription className="text-xs text-slate-500">
-            {heading !== 'Run'
-              ? `Please add ${heading.toLocaleLowerCase()}s with comma separated values.`
-              : ``}
+            {`Please add ${heading.toLocaleLowerCase()}s with comma separated values.`}
           </DialogDescription>
         </>
       }
       contentComponent={
-        heading !== 'Run' ? (
-          <div className="gap-4 py-4">
-            <Input
-              id="name"
-              onChange={(e) => {
-                setValue(e.target.value)
-              }}
-              className="col-span-3"
-              value={value}
-            />
-          </div>
-        ) : (
-          <div className="pb-4">
-            <InputLabels
-              className="text-xs font-normal"
-              labelName="Run Name"
-              isMandatory={true}
-            />
-            <Input
-              id="name"
-              onChange={(e) => {
-                setValue(e.target.value)
-              }}
-              className="col-span-3"
-              value={value}
-            />
-            <InputsSpacing />
-            <InputLabels
-              className="text-xs font-normal"
-              labelName="Run Description"
-            />
-            <Input
-              id="name"
-              onChange={(e) => {
-                setDescription(e.target.value)
-              }}
-              className="col-span-3"
-              value={description}
-            />
-            <div className="text-xs flex flex-col mt-4 text-red-600">
-              <span>
-                *Run will be created with applied[Squads, Labels, Sections,
-                Platform] filter.
-              </span>
-            </div>
-          </div>
-        )
+        <div className="gap-4 py-4">
+          <Input
+            id="name"
+            onChange={(e) => {
+              setValue(e.target.value)
+            }}
+            className="col-span-3"
+            value={value}
+          />
+        </div>
       }
       footerComponent={
         <DialogClose asChild>
           <Button
             type="submit"
             onClick={(_) => {
-              handleSaveChanges(value, description)
+              handleSaveChanges(value)
             }}>
             Add {heading}
           </Button>

--- a/app/screens/TestList/ProjectActions.tsx
+++ b/app/screens/TestList/ProjectActions.tsx
@@ -1,4 +1,3 @@
-import {getInitialSelectedSections} from '@components/SectionList/utils'
 import {useCustomNavigate} from '@hooks/useCustomNavigate'
 import {PlusCircledIcon} from '@radix-ui/react-icons'
 import {useFetcher, useParams} from '@remix-run/react'
@@ -11,12 +10,10 @@ import {
 } from '@ui/dropdown-menu'
 import {toast} from '@ui/use-toast'
 import {MouseEvent, useEffect, useState} from 'react'
-import {useSearchParams} from 'react-router-dom'
 import {Loader} from '~/components/Loader/Loader'
 import {API} from '~/routes/utilities/api'
-import {safeJsonParse} from '~/routes/utilities/utils'
-import {cn} from '~/ui/utils'
 import {AddSquadsLabelsDialog} from './AddSquadsLabelsDialog'
+import {AddRunDialog} from './AddRunDialog'
 
 enum Actions {
   AddTest = 'Test',
@@ -51,7 +48,6 @@ export const ProjectActions = () => {
   const navigate = useCustomNavigate()
   const projectId = useParams().projectId ? Number(useParams().projectId) : 0
   const saveChanges = useFetcher<any>()
-  const [searchParams, _] = useSearchParams()
   const createRun = useFetcher<any>()
   const [actionDD, setActionDD] = useState<boolean>(false)
   const [addSquadDialog, setAddSquadDialog] = useState<boolean>(false)
@@ -140,19 +136,27 @@ export const ProjectActions = () => {
     })
   }
 
-  const handleSaveChangesRuns = (value: string, description?: string) => {
-    const data = {
-      runName: value,
-      runDescription: description ? description : null,
-      squadIds: safeJsonParse(searchParams.get('squadIds') as string),
-      labelIds: safeJsonParse(searchParams.get('labelIds') as string),
-      platformIds: safeJsonParse(searchParams.get('platformIds') as string),
-      sectionIds: getInitialSelectedSections(searchParams),
+  const handleSaveChangesRuns = (data: {
+    runName: string
+    runDescription: string
+    squadIds: number[]
+    labelIds: number[]
+    platformIds: number[]
+    priorityIds: number[]
+    filterType: 'and' | 'or'
+  }) => {
+    const postData = {
+      runName: data.runName,
+      runDescription: data.runDescription || null,
+      squadIds: data.squadIds.length > 0 ? data.squadIds : null,
+      labelIds: data.labelIds.length > 0 ? data.labelIds : null,
+      platformIds: data.platformIds.length > 0 ? data.platformIds : null,
+      priorityIds: data.priorityIds.length > 0 ? data.priorityIds : null,
       projectId,
-      filterType: searchParams.get('filterType'),
+      filterType: data.filterType,
     }
 
-    createRun.submit(data, {
+    createRun.submit(postData, {
       method: 'POST',
       action: `/${API.AddRun}`,
       encType: 'application/json',
@@ -196,8 +200,7 @@ export const ProjectActions = () => {
         state={addSquadDialog}
         setState={setAddSquadDialog}
       />
-      <AddSquadsLabelsDialog
-        heading={Actions.CreateRun}
+      <AddRunDialog
         handleSaveChanges={handleSaveChangesRuns}
         state={addRunDialog}
         setState={setAddRunDialog}

--- a/app/screens/TestList/testTable.interface.ts
+++ b/app/screens/TestList/testTable.interface.ts
@@ -24,6 +24,7 @@ export enum FilterNames {
   Label = 'Label',
   Status = 'Status',
   Platform = 'Platform',
+  Priority = 'Priority',
 }
 
 export enum EditableProperties {


### PR DESCRIPTION
## PR Summary: Enhanced "Add Run" Dialog with Filter Controls

### Overview
This PR enhances the "Add Run" dialog to include comprehensive filter controls directly within the dialog, replacing the need to pre-filter the test list before creating a run.

### Changes

#### New Files
- **`app/screens/TestList/AddRunDialog.tsx`** - A new dedicated dialog component for creating runs with built-in filter capabilities

#### Modified Files

**UI Components:**
- **`app/screens/TestList/ProjectActions.tsx`** - Updated to use the new `AddRunDialog` component and handle priority filter data
- **`app/screens/TestList/AddSquadsLabelsDialog.tsx`** - Simplified to only handle Squads and Labels (removed run-specific code)
- **`app/screens/TestList/testTable.interface.ts`** - Added `Priority` to `FilterNames` enum

**API & Data Layer:**
- **`app/routes/api/v1/createRun.ts`** - Added `priorityIds` to schema and made filter arrays accept `null` values
- **`app/dataController/runs.controller.ts`** - Added `priorityIds` to `ICreateRuns` interface
- **`app/dataController/tests.controller.ts`** - Added `priorityIds` to `ITestsCountController` interface
- **`app/routes/utilities/getSearchParams.ts`** - Added parsing for `priorityIds` in `getTestCount`
- **`app/db/dao/runs.dao.ts`** - Added priority filtering when creating a run
- **`app/db/dao/test.dao.ts`** - Added priority filtering in `getTestsCount`

### Features

The new "Add Run" dialog includes:
- **Run Name** - Required text input (5-50 characters)
- **Run Description** - Optional text input
- **Filter Options:**
  - Squad filter (with "No Squad" option)
  - Label filter
  - Platform filter
  - **Priority filter** (new)
- **Match Criteria** - AND/OR toggle for
<img width="439" height="546" alt="Screenshot 2025-12-03 at 11 24 14 PM" src="https://github.com/user-attachments/assets/59b8e120-d87d-4bae-80d9-aed61e5739ab" />
 combining filters
- **Live Test Count** - Shows how many tests match selected filters
- **Reset Controls** - Reset individual filters or all at once

### Bug Fixes
- Fixed Zod validation error when creating runs without filters by allowing `null` values for filter arrays (`.optional().nullable()`)

### Screenshots
The dialog now shows filter dropdowns directly instead of requiring users to pre-filter the test list page before creating a run.