### PR TITLE
Make Add Test Result comments visible and editable (DFR-1377)

### DIFF
--- a/app/db/dao/testRuns.dao.ts
+++ b/app/db/dao/testRuns.dao.ts
@@ -150,6 +150,7 @@ const TestRunsDao = {
       let testRunsQuery = dbClient
         .select({
           testStatus: sql`MAX(${testRunMap.status})`.as('testStatus'),
+          comment: sql`MAX(${testRunMap.comment})`.as('comment'),
           testId: testRunMap.testId,
           priority: priorityTable.priorityName,
           title: tests.title,

--- a/app/db/schema/runs.ts
+++ b/app/db/schema/runs.ts
@@ -112,7 +112,7 @@ export const testRunMap = mysqlTable(
       .notNull()
       .default(sql`CURRENT_TIMESTAMP`)
       .onUpdateNow(),
-    comment: varchar('comment', {length: 200}),
+    comment: text('comment'),
   },
   (testRunMap) => {
     return {

--- a/app/routes/api/v1/runTestsList.ts
+++ b/app/routes/api/v1/runTestsList.ts
@@ -14,6 +14,7 @@ export interface Tests {
   testId: number
   title: string
   testStatus: string
+  comment: string | null
   priority: string
   platform: string
   squadName: string

--- a/app/screens/RunTestList/AddResultDialog.tsx
+++ b/app/screens/RunTestList/AddResultDialog.tsx
@@ -47,6 +47,16 @@ export const AddResultDialog = ({
   const [comment, setComment] = useState('')
   const [shouldAnimate, setShouldAnimate] = useState(false)
 
+  // Keep status in sync with currStatus so that reopening the dialog to edit
+  // an already-submitted result (e.g. to update the comment) prefills the
+  // existing status instead of leaving it blank and blocking Submit. Also
+  // clear any unsubmitted draft comment so a cancelled edit on one row can't
+  // leak into a later submission for another row/reopen.
+  useEffect(() => {
+    setStatus(currStatus ?? '')
+    setComment('')
+  }, [currStatus])
+
   useEffect(() => {
     if (isAddResultEnabled) {
       setShouldAnimate(true)

--- a/app/screens/RunTestList/RunTestListColumnConfig.tsx
+++ b/app/screens/RunTestList/RunTestListColumnConfig.tsx
@@ -9,6 +9,7 @@ import {
 } from '@radix-ui/react-icons'
 import {useParams} from '@remix-run/react'
 import {ColumnDef} from '@tanstack/react-table'
+import {MessageSquare} from 'lucide-react'
 import {ReactNode, useState} from 'react'
 import {Checkbox} from '~/ui/checkbox'
 import {cn} from '~/ui/utils'
@@ -129,8 +130,9 @@ export const RunTestListColumnConfig: ColumnDef<Tests>[] = [
     cell: ({row}) => {
       const params = useParams()
       const runId = +(params['runId'] ?? 0)
+      const comment = row.original.comment
       return row.original.runStatus === 'Active' ? (
-        <div className="flex items-center justify-center">
+        <div className="flex items-center justify-center gap-1">
           <AddResultDialog
             getSelectedRows={() => {
               return [{testId: row.original.testId}]
@@ -139,10 +141,32 @@ export const RunTestListColumnConfig: ColumnDef<Tests>[] = [
             variant="runRowUpdate"
             currStatus={row.original.testStatus as TestStatusType}
           />
+          {comment && (
+            <Tooltip
+              anchor={
+                <MessageSquare
+                  size={16}
+                  className="text-slate-500 shrink-0 cursor-pointer"
+                />
+              }
+              content={<div className="max-w-[300px]">{comment}</div>}
+            />
+          )}
         </div>
       ) : (
-        <div className="flex items-center justify-center text-sm text-slate-700">
+        <div className="flex items-center justify-center gap-1 text-sm text-slate-700">
           {row.original.testStatus}
+          {comment && (
+            <Tooltip
+              anchor={
+                <MessageSquare
+                  size={16}
+                  className="text-slate-500 shrink-0 cursor-pointer"
+                />
+              }
+              content={<div className="max-w-[300px]">{comment}</div>}
+            />
+          )}
         </div>
       )
     },

--- a/app/screens/TestDetail/TestStatusHistroyDialog.tsx
+++ b/app/screens/TestDetail/TestStatusHistroyDialog.tsx
@@ -37,6 +37,7 @@ export const TestStatusHistroyDialog = ({
             <TableRow>
               <TableHead className="w-[100px]">Status</TableHead>
               <TableHead>Updated By</TableHead>
+              <TableHead>Comment</TableHead>
               <TableHead className="text-right">
                 {pageType === 'testDetail' ? 'Run Name' : 'Updated On'}
               </TableHead>
@@ -47,6 +48,18 @@ export const TestStatusHistroyDialog = ({
               <TableRow key={index}>
                 <TableCell className="truncate">{item.status}</TableCell>
                 <TableCell className="truncate">{item.updatedBy}</TableCell>
+                <TableCell className="max-w-[200px]">
+                  {item.comment ? (
+                    <Tooltip
+                      anchor={<div className="truncate">{item.comment}</div>}
+                      content={
+                        <div className="max-w-[300px]">{item.comment}</div>
+                      }
+                    />
+                  ) : (
+                    '-'
+                  )}
+                </TableCell>
                 <TableCell className="text-right">
                   <Tooltip
                     anchor={


### PR DESCRIPTION
## Summary
- Widens `testRunMap.comment` from varchar(200) to text, fixing silent truncation of longer comments.
- Surfaces the comment in the status-history dialog (both pageType variants) and as a tooltip icon next to Status in the run-list.
- Makes an already-submitted comment editable by prefilling status on dialog reopen, so Submit isn't blocked by the first-time-submission guard.

## Live verification (checkmate-dev.geep-fence.ts.net)
- Submitted a 267-char comment via the real update-test-status API; confirmed it round-trips without truncation in both the run-list and the run-scoped history endpoint.
- Confirmed editing a comment appends a new row to the run-scoped history (`api/v1/run/test-status-history`) while the current-value endpoint (`api/v1/test/test-status-history`) correctly shows only the latest - matches the two-table design already documented in the ticket.
- Schema change applied to the live MySQL DB directly (single additive `ALTER TABLE ... MODIFY COLUMN`), after taking and uploading a full `mysqldump` backup to S3 first.
- Deployed image rebuilt/pushed/rolled out to the live cluster; verified running pod's image digest matches what was pushed.

## Test plan
- [x] `yarn unit:test` - 88 suites / 665 tests pass
- [x] `npx tsc --noEmit` - no new errors (193 pre-existing, unrelated to this diff)
- [x] Live-verified against checkmate-dev per above
- [x] code-reviewer pass, no Blocking findings; one Optional finding (stale draft comment across dialog reopens) addressed by resetting `comment` alongside the `currStatus` sync